### PR TITLE
Fix compiler warnings on linux

### DIFF
--- a/unix/src/c-libedit/common.c
+++ b/unix/src/c-libedit/common.c
@@ -363,15 +363,17 @@ ed_prev_char(EditLine *el, wint_t c __attribute__((__unused__)))
  *	[^V] [^V]
  */
 libedit_private el_action_t
-ed_quoted_insert(EditLine *el, wint_t c)
+/*ARGSUSED*/
+ed_quoted_insert(EditLine *el, wint_t c __attribute__((__unused__)))
 {
 	int num;
+	wchar_t ch;
 
 	tty_quotemode(el);
-	num = el_wgetc(el, &c);
+	num = el_wgetc(el, &ch);
 	tty_noquotemode(el);
 	if (num == 1)
-		return ed_insert(el, c);
+		return ed_insert(el, ch);
 	else
 		return ed_end_of_file(el, 0);
 }

--- a/unix/src/c-libedit/search.c
+++ b/unix/src/c-libedit/search.c
@@ -604,8 +604,10 @@ cv_csearch(EditLine *el, int direction, wint_t ch, int count, int tflag)
 		return CC_ERROR;
 
 	if (ch == (wint_t)-1) {
-		if (el_wgetc(el, &ch) != 1)
+		wchar_t c;
+		if (el_wgetc(el, &c) != 1)
 			return ed_end_of_file(el, 0);
+		ch = c;
 	}
 
 	/* Save for ';' and ',' commands */


### PR DESCRIPTION
Fix #2.

---

I realize this came from upstream, but, ¯\_(ツ)_/¯ , it seems broken.