### PR TITLE
Provide secure_getenv on Linux where possible

### DIFF
--- a/unix/c_editline_linux.c
+++ b/unix/c_editline_linux.c
@@ -1,0 +1,22 @@
+#include <features.h>
+
+#ifndef __GLIBC__
+
+// secure_getenv is missing in musl, but it can be trivially implemented in
+// terms of issetugid.
+//
+// Note that we must assume we're compiling against musl if we're not compiling
+// against glibc because musl doesn't define a __MUSL__ macro [0]. Ideally we'd
+// just check for the presence of secure_getenv, but cgo provides no facility
+// for doing so.
+//
+// [0]: https://wiki.musl-libc.org/faq.html#Q:-Why-is-there-no-%3Ccode%3E__MUSL__%3C/code%3E-macro?
+#include <stdlib.h>
+#include <unistd.h>
+char *secure_getenv(char const *name) {
+	if (issetugid())
+		return 0;
+	return getenv(name);
+}
+
+#endif /* !__GLIBC__ */

--- a/unix/src/c-libedit/linux-build/config.h
+++ b/unix/src/c-libedit/linux-build/config.h
@@ -83,7 +83,7 @@
 #define HAVE_RE_COMP 1
 
 /* Define to 1 if you have the `secure_getenv' function. */
-/* #undef HAVE_SECURE_GETENV */
+#define HAVE_SECURE_GETENV 1
 
 /* Define to 1 if `stat' has the bug that it succeeds when given the
    zero-length file name argument. */
@@ -283,3 +283,5 @@
 /* #undef LIBC_SCCS */
 #define lint
 
+// Code automatically added by refresh.sh.
+#include "shims.h"

--- a/unix/src/c-libedit/linux-build/shims.h
+++ b/unix/src/c-libedit/linux-build/shims.h
@@ -1,0 +1,11 @@
+#include <features.h>
+
+#ifdef __GLIBC__
+// Only __secure_getenv exists prior to glibc 2.17.
+#if __GLIBC__ <= 2 && __GLIBC_MINOR__ < 17
+#define secure_getenv __secure_getenv
+#endif
+#else
+// We provide a shim implementation for other C libraries.
+char *secure_getenv(char const *name);
+#endif

--- a/unix/src/refresh.sh
+++ b/unix/src/refresh.sh
@@ -13,7 +13,7 @@ apt-get source libedit
 
 mkdir build
 (cd build \
-     && export ac_cv_func_secure_getenv=no \
+     && export ac_cv_func_secure_getenv=yes \
      && export ac_cv_func___secure_getenv=no \
      && export ac_cv_header_sys_cdefs_h=no \
      && export ac_cv_header_curses_h=no \
@@ -26,6 +26,14 @@ mkdir -p c-libedit/linux-build c-libedit/editline
 cp -a libedit-*/src/editline c-libedit/
 cp -a libedit-*/src/*.[ch] c-libedit/
 cp -a build/config.h build/src/*.h c-libedit/linux-build/
+
+# We shim some functions that are conventionally declared in system header
+# files. config.h is a convenient place to inject declarations for these
+# functions, as it's included by every translation unit.
+cat <<EOF > c-libedit/linux-build/config.h
+// Code automatically added by refresh.sh.
+#include "shims.h"
+EOF
 
 # This Linux readline is out of sync with the main BSD repo. The Newer
 # BSD readlines have 3 extra arguments on fn_complete().  Make them


### PR DESCRIPTION
In order to source ~/.editrc, libedit looks up the value of the HOME
environment variable using secure_getenv. Previously, because
HAVE_SECURE_GETENV was not defined when compiling libedit on Linux,
libedit would be unable to lookup HOME and give up on sourcing
~/.editrc.

Defining HAVE_SECURE_GETENV fixes the problem, but only with glibc.
Musl does not provide a secure_getenv function. Work around that by
providing a shim implementation of secure_getenv for musl that uses the
issetugid function instead.

Compilation against a non-glibc library that does not provide issetugid
will fail. I don't think it's possible to fix this (i.e., compiling but
refusing to lookup HOME at runtime) while continuing to compile libedit
with cgo, though.

Fix #3.