### PR TITLE
Support secure_getenv so that $HOME/.editrc can be read on linux / GNU libc

### DIFF
--- a/unix/editline_unix.go
+++ b/unix/editline_unix.go
@@ -16,7 +16,7 @@ import (
 // #cgo openbsd netbsd freebsd dragonfly darwin CPPFLAGS: -Ishim
 // #cgo linux LDFLAGS: -lncurses
 // #cgo linux CFLAGS: -Wno-unused-result
-// #cgo linux CPPFLAGS: -Isrc -Isrc/c-libedit -Isrc/c-libedit/editline -Isrc/c-libedit/linux-build
+// #cgo linux CPPFLAGS: -Isrc -Isrc/c-libedit -Isrc/c-libedit/editline -Isrc/c-libedit/linux-build -D_GNU_SOURCE
 // #cgo darwin CPPFLAGS: -D__darwin__=1
 //
 // #include <stdlib.h>

--- a/unix/src/c-libedit/el.c
+++ b/unix/src/c-libedit/el.c
@@ -66,13 +66,21 @@ __RCSID("$NetBSD: el.c,v 1.92 2016/05/22 19:44:26 christos Exp $");
 #		define secure_getenv __secure_getenv
 #		define HAVE_SECURE_GETENV 1
 #	else
-#		ifdef HAVE_ISSETUGID
-#			include <unistd.h>
-#		else
+#		include <unistd.h>
+#		ifndef HAVE_ISSETUGID
 #			undef issetugid
-#			define issetugid() 1
+#			define issetugid() (getuid() != geteuid() || getgid() != getegid())
 #		endif
 #	endif
+#endif
+
+#if !defined(HAVE_SECURE_GETENV) && defined(__GLIBC__)
+#      if __GLIBC__ >= 2
+#              if __GLIBC__ > 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ < 17)
+#                      define secure_getenv __secure_getenv
+#              endif
+#              define HAVE_SECURE_GETENV 1
+#      endif
 #endif
 
 #ifndef HAVE_SECURE_GETENV

--- a/unix/src/refresh.sh
+++ b/unix/src/refresh.sh
@@ -32,6 +32,11 @@ cp -a build/config.h build/src/*.h c-libedit/linux-build/
 # exist so that the C calls don't crash.
 patch -p1 <fncomplete.patch
 
+# This ensures that the GNU libc secure_getenv is used when available.
+patch -p1 <secure_getenv.patch
+
+rm -f c-libedit/*.orig
+
 (cd c-libedit &&
      for i in *.c; do
 	 echo "#include \"$i\"">../libedit-$i

--- a/unix/src/secure_getenv.patch
+++ b/unix/src/secure_getenv.patch
@@ -1,0 +1,30 @@
+--- a/c-libedit/el.c
++++ b/c-libedit/el.c
+@@ -66,15 +66,23 @@ __RCSID("$NetBSD: el.c,v 1.92 2016/05/22 19:44:26 christos Exp $");
+ #		define secure_getenv __secure_getenv
+ #		define HAVE_SECURE_GETENV 1
+ #	else
+-#		ifdef HAVE_ISSETUGID
+-#			include <unistd.h>
+-#		else
++#		include <unistd.h>
++#		ifndef HAVE_ISSETUGID
+ #			undef issetugid
+-#			define issetugid() 1
++#			define issetugid() (getuid() != geteuid() || getgid() != getegid())
+ #		endif
+ #	endif
+ #endif
+ 
++#if !defined(HAVE_SECURE_GETENV) && defined(__GLIBC__)
++#      if __GLIBC__ >= 2
++#              if __GLIBC__ > 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ < 17)
++#                      define secure_getenv __secure_getenv
++#              endif
++#              define HAVE_SECURE_GETENV 1
++#      endif
++#endif
++
+ #ifndef HAVE_SECURE_GETENV
+ char *secure_getenv(char const *name)
+ {


### PR DESCRIPTION
Needed for  #3  -- and any kind of .editrc customization on linux, really. The secure_getenv shim we were providing previously had `secure_getenv()` return NULL always.

Supersedes #9.