### PR TITLE
Provide a replacement fn_complete for macOS Mojave (10.14)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,20 @@ To force the package to use a system-wide libedit instead, edit `unix/editline_u
 - change the line containing `#cgo linux CPPFLAGS` to read: `#cgo linux CPPFLAGS: -I/usr/include/editline -Ishim`
 - change the line containing `#cgo linux LDFLAGS` to read: `#cgo linux LDFLAGS: -ledit`
 
+## macOS/OSX due to restrictions due to changes macOS Mojave
+
+macOS Mojave is shipped with a broken/restricted libedit where the
+completion API is not published. Because it is not possible to
+automatically detect macOS versions, **go-libedit** will use a reduced
+autocompletion facility on all versions of macOS instead.
+
+This autocompletion facility lacks the following features from libedit:
+
+- it cannot autocomplete file and directory names.
+- it does not display a list of possible completions. Only the fact
+  that more than 1 completion is available is signalled using
+  a terminal beep.
+
 ## How to refresh the bundled libedit sources
 
 (Only needed when upgrading the bundled `libedit` to a newer version.)

--- a/unix/c_editline.c
+++ b/unix/c_editline.c
@@ -9,6 +9,7 @@
 #include <unistd.h>
 #include <string.h>
 #include <wchar.h>
+#include <limits.h>
 
 #include "c_editline.h"
 
@@ -304,8 +305,11 @@ int go_libedit_add_history(History *h, char *line) {
 // own. So basically re-implement on top of editline's internal
 // fn_complete function.
 
-int
-fn_complete(EditLine *el,
+// Except that the folk at OSX/Darwin have decided that fn_complete
+// should not be exported so we can't use any of that on that platform.
+
+#if !defined(__APPLE__) || !defined(__MACH__)
+int fn_complete(EditLine *el,
 	    char *(*complet_func)(const char *, int),
 	    char **(*attempted_completion_function)(const char *, int, int),
 	    const wchar_t *word_break, const wchar_t *special_prefixes,
@@ -314,6 +318,10 @@ fn_complete(EditLine *el,
 	    const wchar_t *(*find_word_start_func)(const wchar_t *, const wchar_t *),
 	    wchar_t *(*dequoting_func)(const wchar_t *),
 	    char *(*quoting_func)(const char *));
+#else
+#include "stub_fn_complete.i"
+#endif
+
 static const wchar_t break_chars[] = L" \t\n\"\\'`@$><=;|&{(";
 
 

--- a/unix/stub_find_word_to_complete.i
+++ b/unix/stub_find_word_to_complete.i
@@ -1,0 +1,75 @@
+/*-
+ * Copyright (c) 1997 The NetBSD Foundation, Inc.
+ * All rights reserved.
+ *
+ * This code is derived from software contributed to The NetBSD Foundation
+ * by Jaromir Dolecek.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE NETBSD FOUNDATION, INC. AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE FOUNDATION OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// These functions are auxiliaries for the code in
+// stub_fn_complete.i.
+
+static wchar_t *
+find_word_to_complete(const wchar_t * cursor, const wchar_t * buffer,
+    const wchar_t * word_break, const wchar_t * special_prefixes, size_t * length)
+{
+	/* We now look backwards for the start of a filename/variable word */
+	const wchar_t *ctemp = cursor;
+	int cursor_at_quote;
+	size_t len;
+	wchar_t *temp;
+
+	/* if the cursor is placed at a slash or a quote, we need to find the
+	 * word before it
+	 */
+	if (ctemp > buffer) {
+		switch (ctemp[-1]) {
+		case '\\':
+		case '\'':
+		case '"':
+			cursor_at_quote = 1;
+			ctemp--;
+			break;
+		default:
+			cursor_at_quote = 0;
+		}
+	} else
+		cursor_at_quote = 0;
+
+	while (ctemp > buffer
+	    && !wcschr(word_break, ctemp[-1])
+	    && (!special_prefixes || !wcschr(special_prefixes, ctemp[-1])))
+		ctemp--;
+
+	len = (size_t) (cursor - ctemp - cursor_at_quote);
+	temp = malloc((len + 1) * sizeof(*temp));
+	if (temp == NULL)
+		return NULL;
+	(void) wcsncpy(temp, ctemp, len);
+	temp[len] = '\0';
+	if (cursor_at_quote)
+		len++;
+	*length = len;
+	return temp;
+}

--- a/unix/stub_fn_complete.i
+++ b/unix/stub_fn_complete.i
@@ -133,7 +133,7 @@ char *multibyte_to_singlebyte(wchar_t *s) {
 		if (!*s)
 			/* nothing remaining to convert. */
 			break;
-		
+
 		/* convert one character */
 		int l = wctomb(buf + i, *s);
 		if (l < 0) {
@@ -155,7 +155,8 @@ wchar_t *singlebyte_to_multibyte(char *s) {
 	if (len == (size_t)-1)
 		return NULL;
 
-	/* make space. */
+	/* make space. len does not count the final NUL so we need to add it here. */
+	len++;
 	wchar_t * r = malloc(len * sizeof(wchar_t));
 	if (r)
 		/* do the actual conversion. */

--- a/unix/stub_fn_complete.i
+++ b/unix/stub_fn_complete.i
@@ -1,0 +1,164 @@
+// This is a stub provided for compatibility with macOS Mojave and
+// other possible systems that have decided they didn't want to export
+// the true fn_complete().
+// This stub does not perform filename completion and does not
+// offer a selection menu. It also does not offer compatibility
+// with readline() (via the completion_type argument).
+
+#include "stub_find_word_to_complete.i"
+
+static char *multibyte_to_singlebyte(wchar_t *line);
+static wchar_t *singlebyte_to_multibyte(char *line);
+
+static
+int fn_complete(
+	EditLine *el,
+	char *(*complet_func)(const char *, int), // ignored
+	char **(*attempted_completion_function)(const char *, int, int),
+	const wchar_t *word_break,
+	const wchar_t *special_prefixes, // ignored
+	const char *(*app_func)(const char *), // ignored
+	size_t query_items,
+	int *completion_type, // ignored
+	int *over, // ignored
+	int *point, // ignored
+	int *end, // ignored
+	const wchar_t *(*find_word_start_func)(const wchar_t *, const wchar_t *), // ignored
+	wchar_t *(*dequoting_func)(const wchar_t *), // ignored
+	char *(*quoting_func)(const char *) // ignored
+	)
+{
+	char *completion_prefix;
+	size_t completion_prefix_len;
+	wchar_t *temp;
+	int cur_off;
+	char **matches;
+	int retval = CC_NORM;
+
+	if (!attempted_completion_function)
+		/* nothing to do. We don't support file completion here. */
+		goto out;
+
+	const LineInfoW *li = el_wline(el);
+
+	/*
+	 * isolate the completion prefix.
+	 */
+	temp = find_word_to_complete(
+		li->cursor,
+		li->buffer, word_break, special_prefixes,
+		&completion_prefix_len);
+	if (temp == NULL)
+		/* nothing to do. */
+		goto out;
+
+	completion_prefix = multibyte_to_singlebyte(temp);
+
+	/*
+	 * compute the completion matches.
+	 */
+
+	/* cursor offset from begin of the line. */
+	cur_off = (int)(li->cursor - li->buffer);
+	/* compute the completion matches. */
+	matches = (*attempted_completion_function)(
+		completion_prefix, cur_off - (int)completion_prefix_len, cur_off);
+
+	if (!matches)
+		/* nothing to do any more. */
+		goto out;
+
+	int single_match = matches[2] == NULL &&
+		(matches[1] == NULL || strcmp(matches[0], matches[1]) == 0);
+
+	if (matches[0][0] != '\0') {
+		/* clear the completion prefix. */
+		el_deletestr(el, (int) completion_prefix_len);
+
+		/* compute the completion to display. */
+		wchar_t *completion = singlebyte_to_multibyte(matches[0]);
+		if (!completion)
+			goto out;
+
+		/* print it. */
+		el_winsertstr(el, completion);
+		free(completion);
+
+		if (single_match)
+			/* insert a space after the match. */
+			el_winsertstr(el, L" ");
+
+		/* show the completion result upon returning. */
+		retval = CC_REFRESH;
+	}
+	if (!single_match && matches[0][0])
+		/* some common match but not complete match.
+		 * inform the user the input is still incomplete. */
+		el_beep(el);
+
+out:
+	/*
+	 * release resources and complete.
+	 */
+	if (matches) {
+		for (size_t i = 0; matches[i]; i++)
+			free(matches[i]);
+		free(matches);
+	}
+	if (completion_prefix) {
+		free(completion_prefix);
+	}
+	if (temp) {
+		free(temp);
+	}
+	return retval;
+}
+
+char *multibyte_to_singlebyte(wchar_t *s) {
+	char *buf = NULL;
+	size_t i = 0;
+	size_t bufsz = 0;
+	do {
+		/* the +1 below is to make space for the final NUL byte */
+		if (i + MB_LEN_MAX + 1 >= bufsz) {
+			/* out of space. */
+			bufsz = (bufsz == 0 ? 1024 : bufsz * 2);
+			char *newbuf = realloc(buf, bufsz);
+			if (newbuf == NULL) {
+				free(buf);
+				return NULL;
+			}
+			buf = newbuf;
+		}
+		if (!*s)
+			/* nothing remaining to convert. */
+			break;
+		
+		/* convert one character */
+		int l = wctomb(buf + i, *s);
+		if (l < 0) {
+			/* reset the converter */
+			wctomb(NULL, L'\0');
+			free(buf);
+			return NULL;
+		}
+		i += l;
+		s++;
+	} while(1);
+	buf[i] = '\0';
+	return buf;
+}
+
+wchar_t *singlebyte_to_multibyte(char *s) {
+	/* compute the multibyte len. */
+	size_t len = mbstowcs(NULL, s, 0);
+	if (len == (size_t)-1)
+		return NULL;
+
+	/* make space. */
+	wchar_t * r = malloc(len * sizeof(wchar_t));
+	if (r)
+		/* do the actual conversion. */
+		mbstowcs(r, s, len);
+	return r;
+}


### PR DESCRIPTION
Subsumes #12.

The code here is a cleanroom reimplementation and does not use the editline internals.