### PR TITLE
Ignore pointer-sign conversion warnings

### DIFF
--- a/unix/editline_unix.go
+++ b/unix/editline_unix.go
@@ -29,7 +29,7 @@ import (
 // #cgo openbsd netbsd freebsd dragonfly darwin LDFLAGS: -ledit
 // #cgo openbsd netbsd freebsd dragonfly darwin CPPFLAGS: -Ishim
 // #cgo linux LDFLAGS: -lncurses
-// #cgo linux CFLAGS: -Wno-unused-result
+// #cgo linux CFLAGS: -Wno-unused-result -Wno-pointer-sign
 // #cgo linux CPPFLAGS: -Isrc -Isrc/c-libedit -Isrc/c-libedit/editline -Isrc/c-libedit/linux-build -D_GNU_SOURCE
 // #cgo darwin CPPFLAGS: -D__darwin__=1
 //


### PR DESCRIPTION
These warnings have started to affect downstream dependencies
somehow. They are innocuous, so don't bother warning on them.