### PR TITLE
Allow opting out of building libedit on Linux

### DIFF
--- a/unix/src/libedit-chared.c
+++ b/unix/src/libedit-chared.c
@@ -1,1 +1,3 @@
+#ifndef GO_LIBEDIT_NO_BUILD
 #include "chared.c"
+#endif

--- a/unix/src/libedit-chartype.c
+++ b/unix/src/libedit-chartype.c
@@ -1,1 +1,3 @@
+#ifndef GO_LIBEDIT_NO_BUILD
 #include "chartype.c"
+#endif

--- a/unix/src/libedit-common.c
+++ b/unix/src/libedit-common.c
@@ -1,1 +1,3 @@
+#ifndef GO_LIBEDIT_NO_BUILD
 #include "common.c"
+#endif

--- a/unix/src/libedit-el.c
+++ b/unix/src/libedit-el.c
@@ -1,1 +1,3 @@
+#ifndef GO_LIBEDIT_NO_BUILD
 #include "el.c"
+#endif

--- a/unix/src/libedit-eln.c
+++ b/unix/src/libedit-eln.c
@@ -1,1 +1,3 @@
+#ifndef GO_LIBEDIT_NO_BUILD
 #include "eln.c"
+#endif

--- a/unix/src/libedit-emacs.c
+++ b/unix/src/libedit-emacs.c
@@ -1,1 +1,3 @@
+#ifndef GO_LIBEDIT_NO_BUILD
 #include "emacs.c"
+#endif

--- a/unix/src/libedit-filecomplete.c
+++ b/unix/src/libedit-filecomplete.c
@@ -1,1 +1,3 @@
+#ifndef GO_LIBEDIT_NO_BUILD
 #include "filecomplete.c"
+#endif

--- a/unix/src/libedit-hist.c
+++ b/unix/src/libedit-hist.c
@@ -1,1 +1,3 @@
+#ifndef GO_LIBEDIT_NO_BUILD
 #include "hist.c"
+#endif

--- a/unix/src/libedit-history.c
+++ b/unix/src/libedit-history.c
@@ -1,1 +1,3 @@
+#ifndef GO_LIBEDIT_NO_BUILD
 #include "history.c"
+#endif

--- a/unix/src/libedit-historyn.c
+++ b/unix/src/libedit-historyn.c
@@ -1,1 +1,3 @@
+#ifndef GO_LIBEDIT_NO_BUILD
 #include "historyn.c"
+#endif

--- a/unix/src/libedit-keymacro.c
+++ b/unix/src/libedit-keymacro.c
@@ -1,1 +1,3 @@
+#ifndef GO_LIBEDIT_NO_BUILD
 #include "keymacro.c"
+#endif

--- a/unix/src/libedit-map.c
+++ b/unix/src/libedit-map.c
@@ -1,1 +1,3 @@
+#ifndef GO_LIBEDIT_NO_BUILD
 #include "map.c"
+#endif

--- a/unix/src/libedit-parse.c
+++ b/unix/src/libedit-parse.c
@@ -1,1 +1,3 @@
+#ifndef GO_LIBEDIT_NO_BUILD
 #include "parse.c"
+#endif

--- a/unix/src/libedit-prompt.c
+++ b/unix/src/libedit-prompt.c
@@ -1,1 +1,3 @@
+#ifndef GO_LIBEDIT_NO_BUILD
 #include "prompt.c"
+#endif

--- a/unix/src/libedit-read.c
+++ b/unix/src/libedit-read.c
@@ -1,1 +1,3 @@
+#ifndef GO_LIBEDIT_NO_BUILD
 #include "read.c"
+#endif

--- a/unix/src/libedit-readline.c
+++ b/unix/src/libedit-readline.c
@@ -1,1 +1,3 @@
+#ifndef GO_LIBEDIT_NO_BUILD
 #include "readline.c"
+#endif

--- a/unix/src/libedit-refresh.c
+++ b/unix/src/libedit-refresh.c
@@ -1,1 +1,3 @@
+#ifndef GO_LIBEDIT_NO_BUILD
 #include "refresh.c"
+#endif

--- a/unix/src/libedit-search.c
+++ b/unix/src/libedit-search.c
@@ -1,1 +1,3 @@
+#ifndef GO_LIBEDIT_NO_BUILD
 #include "search.c"
+#endif

--- a/unix/src/libedit-sig.c
+++ b/unix/src/libedit-sig.c
@@ -1,1 +1,3 @@
+#ifndef GO_LIBEDIT_NO_BUILD
 #include "sig.c"
+#endif

--- a/unix/src/libedit-strlcat.c
+++ b/unix/src/libedit-strlcat.c
@@ -1,1 +1,3 @@
+#ifndef GO_LIBEDIT_NO_BUILD
 #include "strlcat.c"
+#endif

--- a/unix/src/libedit-strlcpy.c
+++ b/unix/src/libedit-strlcpy.c
@@ -1,1 +1,3 @@
+#ifndef GO_LIBEDIT_NO_BUILD
 #include "strlcpy.c"
+#endif

--- a/unix/src/libedit-terminal.c
+++ b/unix/src/libedit-terminal.c
@@ -1,1 +1,3 @@
+#ifndef GO_LIBEDIT_NO_BUILD
 #include "terminal.c"
+#endif

--- a/unix/src/libedit-tokenizer.c
+++ b/unix/src/libedit-tokenizer.c
@@ -1,1 +1,3 @@
+#ifndef GO_LIBEDIT_NO_BUILD
 #include "tokenizer.c"
+#endif

--- a/unix/src/libedit-tokenizern.c
+++ b/unix/src/libedit-tokenizern.c
@@ -1,1 +1,3 @@
+#ifndef GO_LIBEDIT_NO_BUILD
 #include "tokenizern.c"
+#endif

--- a/unix/src/libedit-tty.c
+++ b/unix/src/libedit-tty.c
@@ -1,1 +1,3 @@
+#ifndef GO_LIBEDIT_NO_BUILD
 #include "tty.c"
+#endif

--- a/unix/src/libedit-unvis.c
+++ b/unix/src/libedit-unvis.c
@@ -1,1 +1,3 @@
+#ifndef GO_LIBEDIT_NO_BUILD
 #include "unvis.c"
+#endif

--- a/unix/src/libedit-vi.c
+++ b/unix/src/libedit-vi.c
@@ -1,1 +1,3 @@
+#ifndef GO_LIBEDIT_NO_BUILD
 #include "vi.c"
+#endif

--- a/unix/src/libedit-vis.c
+++ b/unix/src/libedit-vis.c
@@ -1,1 +1,3 @@
+#ifndef GO_LIBEDIT_NO_BUILD
 #include "vis.c"
+#endif

--- a/unix/src/libedit-wcsdup.c
+++ b/unix/src/libedit-wcsdup.c
@@ -1,1 +1,3 @@
+#ifndef GO_LIBEDIT_NO_BUILD
 #include "wcsdup.c"
+#endif

--- a/unix/src/refresh.sh
+++ b/unix/src/refresh.sh
@@ -39,7 +39,9 @@ rm -f c-libedit/*.orig
 
 (cd c-libedit &&
      for i in *.c; do
-	 echo "#include \"$i\"">../libedit-$i
+	 echo "#ifndef GO_LIBEDIT_NO_BUILD">../libedit-$i
+	 echo "#include \"$i\"">>../libedit-$i
+	 echo "#endif">>../libedit-$i
 	 echo "// Nothing to see here.">../../shim/libedit-$i
 	 echo "#include \"libedit-$i\"">../../wrap-$i
      done)


### PR DESCRIPTION
This will allow CockroachDB to provide its own patched copy of libedit
without breaking `go build` for other consumers of this library.