### PR TITLE
gitignore: ignore cgo flags files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,7 @@ modules.order
 Module.symvers
 Mkfile.old
 dkms.conf
+
+# Generated Go code that may be injected by downstream dependencies
+# (e.g., CockroachDB) into a vendored copy of this library.
+zcgo_flags*.go


### PR DESCRIPTION
This library does not directly generate cgo flags files, but CockroachDB
needs to, in order to configure this library to link against a different
version of libedit. We are unfortunately responsible for ignoring these
files, because dep does not permit .gitignores that are not part of the
upstream library.